### PR TITLE
Add Zlib/PNG LICENSE.txt file

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,13 @@
+Tiny Renderer, https://github.com/ssloy/tinyrenderer
+Copyright Dmitry V. Sokolov
+
+This software is provided 'as-is', without any express or implied warranty.
+In no event will the authors be held liable for any damages arising from the use of this software.
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it freely,
+subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.
+


### PR DESCRIPTION
Thanks for sharing this nice educational little software renderer. It would be good to attach some permissive license file, such as the Zlib/PNG license.

Attached is the LICENSE.txt file with the appropriate license text (the same license as used by the zlib, PNG, Bullet and Box2D).

This helps derived work, which may or may not be relevant (depends who you ask)  :-)