### PR TITLE
Fix faults in Make builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.o
+*.d
 framebuffer.tga
 main

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SYSCONF_LINK = g++
-CPPFLAGS     = -Wall -Wextra -Weffc++ -pedantic -std=c++98
+CPPFLAGS     = -MD -Wall -Wextra -Weffc++ -pedantic -std=c++98
 LDFLAGS      = -O3
 LIBS         = -lm
 
@@ -7,6 +7,7 @@ DESTDIR = ./
 TARGET  = main
 
 OBJECTS := $(patsubst %.cpp,%.o,$(wildcard *.cpp))
+DEPS=$(OBJECTS:.o=.d)
 
 all: $(DESTDIR)$(TARGET)
 
@@ -20,4 +21,6 @@ clean:
 	-rm -f $(OBJECTS)
 	-rm -f $(TARGET)
 	-rm -f *.tga
+	-rm -f $(DEPS)
 
+-include $(DEPS)


### PR DESCRIPTION
Hello

This pull request improves the build script of this project.
Specifically, it adds missing Make dependencies so that the targets of the project are re-generated correctly whenever there are updates to any of the dependent source files.

In this way, the project is incrementally built.

Note that this fix follows the best practices for tracking dependencies automatically (through gcc -MD)

For more details, see here.
https://www.gnu.org/software/make/manual/html_node/Automatic-Prerequisites.html