### PR TITLE
Fix faults in Make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
 SYSCONF_LINK = g++
-CPPFLAGS     = -Wall -Wextra -Weffc++ -pedantic -std=c++98
+CPPFLAGS     = -Wall -Wextra -Weffc++ -pedantic -std=c++98 -MD
 LDFLAGS      = -O3
 LIBS         = -lm
 
 DESTDIR = ./
 TARGET  = main
 
+DEPS=$(wildcard *.d)
 OBJECTS := $(patsubst %.cpp,%.o,$(wildcard *.cpp))
+
 
 all: $(DESTDIR)$(TARGET)
 
@@ -20,4 +22,6 @@ clean:
 	-rm -f $(OBJECTS)
 	-rm -f $(TARGET)
 	-rm -f *.tga
+	-rm -f $(DEPS)
 
+-include $(OBJECTS:.o=.d)


### PR DESCRIPTION
Hello

This pull request fixes the build script of this project.
Specifically, it adds missing Make dependencies so that the targets of the project are re-generated correctly whenever there are updates to any of the dependent source files.

In this way, the project is incrementally built and we no longer sacrifice time in clean builds (i.e., builds after a make clean).

Note that this fix follows the best practices for tracking dependencies automatically (through gcc -MD)

For more details, see here.
https://www.gnu.org/software/make/manual/html_node/Automatic-Prerequisites.html