### PR TITLE
modernize/simplify cmake. Make release take effect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-build/
 framebuffer.tga

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,11 +2,8 @@ image:
   file: Dockerfile
 tasks:
 - command: >
-    mkdir --parents build &&
-    cd build &&
-    cmake .. &&
-    make &&
-    ./tinyrenderer ../obj/diablo3_pose/diablo3_pose.obj ../obj/floor.obj &&
+    cmake -Bbuild &&
+    cmake --build build --parallel &&
+    build/tinyrenderer obj/diablo3_pose/diablo3_pose.obj obj/floor.obj &&
     convert framebuffer.tga framebuffer.png &&
-    open framebuffer.png &&
-    cd ..
+    open framebuffer.png

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,12 @@ project(tinyrenderer LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 
+option(iwyu "Run include-what-you-use")
+if(iwyu)
+  find_program(IWYU_EXE NAMES include-what-you-use REQUIRED)
+  set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${IWYU_EXE})
+endif()
+
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU|Intel")
   add_compile_options(-Wall)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,21 +1,23 @@
-cmake_minimum_required (VERSION 3.1)
-project(tinyrenderer)
+cmake_minimum_required(VERSION 3.12...3.26)
+
+get_property(is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(NOT is_multi_config AND NOT (CMAKE_BUILD_TYPE OR DEFINED ENV{CMAKE_BUILD_TYPE}))
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Release default")
+endif()
+
+project(tinyrenderer LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(OpenMP)
-if(OPENMP_FOUND)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU|Intel")
+  add_compile_options(-Wall)
 endif()
 
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
-endif()
+find_package(OpenMP COMPONENTS CXX)
 
-file(GLOB SOURCES *.h *.cpp)
+set(SOURCES geometry.cpp main.cpp model.cpp our_gl.cpp tgaimage.cpp)
 
 add_executable(${PROJECT_NAME} ${SOURCES})
+target_link_libraries(${PROJECT_NAME} PRIVATE $<$<BOOL:${OpenMP_CXX_FOUND}>:OpenMP::OpenMP_CXX>)
 
+file(GENERATE OUTPUT .gitignore CONTENT "*")

--- a/README.md
+++ b/README.md
@@ -3,14 +3,13 @@
 # Check [the wiki](https://github.com/ssloy/tinyrenderer/wiki) for the detailed lessons.
 
 ## compilation
+
 ```sh
-git clone https://github.com/ssloy/tinyrenderer.git &&
-cd tinyrenderer &&
-mkdir build &&
-cd build &&
-cmake .. &&
-cmake --build . -j &&
-./tinyrenderer ../obj/diablo3_pose/diablo3_pose.obj ../obj/floor.obj
+git clone https://github.com/ssloy/tinyrenderer.git
+cd tinyrenderer
+cmake -Bbuild
+cmake --build build -j
+build/tinyrenderer obj/diablo3_pose/diablo3_pose.obj obj/floor.obj
 ```
 The rendered image is saved to `framebuffer.tga`.
 
@@ -62,6 +61,6 @@ output.tga should look something like this:
 
 ![](https://raw.githubusercontent.com/ssloy/tinyrenderer/gh-pages/img/00-home/diablo-glow.png)
 
-![](https://raw.githubusercontent.com/ssloy/tinyrenderer/gh-pages/img/00-home/boggie.png) 
+![](https://raw.githubusercontent.com/ssloy/tinyrenderer/gh-pages/img/00-home/boggie.png)
 
 ![](https://raw.githubusercontent.com/ssloy/tinyrenderer/gh-pages/img/00-home/diablo-ssao.png)


### PR DESCRIPTION
CMake >= 3.12 required for CMAKE_CXX_STANDARD 20
Actually build in release mode
add -Wall

This works with all compilers tried (Clang, GCC, Visual Studio, Intel oneAPI, NVIDIA HPC)